### PR TITLE
XRebel proposition

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,25 +68,34 @@ const es6Rules = {
 };
 
 const reactRules = {
-    "display-name": 0,
 
-    "prop-types": 0,
+    "no-deprecated": 2,
 
-    "no-find-dom-node": 0,
+    "no-direct-mutation-state": 2,
+
+    "no-find-dom-node": 2,
+
+    "no-is-mounted": 2,
+
+    "no-render-return-value": 2,
+
+    "no-string-refs": 2,
+
+    "no-unknown-property": 2,
+
+    "prefer-es6-class": 2,
+
+    "react-in-jsx-scope": 2,
+
+    "self-closing-comp": 2,
+
+    "style-prop-object": 2,
 
     "jsx-closing-bracket-location": [2, "line-aligned"],
 
     "jsx-indent": [2, 4],
 
     "jsx-indent-props": [2, 4],
-
-    "style-prop-object": 2,
-
-    "self-closing-comp": 2,
-
-    "prefer-es6-class": 2,
-
-    "no-string-refs": 2,
 
     "jsx-space-before-closing": 2,
 
@@ -96,15 +105,22 @@ const reactRules = {
 
     "jsx-pascal-case": 2,
 
-    "jsx-max-props-per-line": [2, { maximum: 5 }],
+    "jsx-max-props-per-line": [2, { maximum: 3 }],
+
+    "jsx-no-duplicate-props": 2,
+
+    "jsx-no-undef": 2,
+
+    "jsx-uses-react": 2,
+
+    "jsx-uses-vars": 2,
 
     "jsx-wrap-multilines": 2,
 };
 
 module.exports = {
     extends: [
-        "eslint:recommended",
-        "plugin:react/recommended"
+        "eslint:recommended"
     ],
 
     env: {

--- a/index.js
+++ b/index.js
@@ -85,10 +85,6 @@ const bestPracticeRules = {
     "radix": 2,
 };
 
-const strictModeRules = {
-    "strict": 2,
-};
-
 const variablesRules = {
     "no-delete-var": 2,
 
@@ -228,7 +224,6 @@ module.exports = {
         {},
         possibleErrorRules,
         bestPracticeRules,
-        strictModeRules,
         variablesRules,
         styleRules,
         es6Rules,

--- a/index.js
+++ b/index.js
@@ -1,44 +1,124 @@
 const never = "never";
 const always = "always";
 
-const bestPractices = {
+const possibleErrorRules = {
+    "no-cond-assign": 2,
+
+    "no-console": 2,
+
+    "no-constant-condition": 2,
+
+    "no-control-regex": 2,
+
+    "no-debugger": 2,
+
+    "no-dupe-args": 2,
+
+    "no-dupe-keys": 2,
+
+    "no-duplicate-case": 2,
+
+    "no-empty": 2,
+
+    "no-empty-character-class": 2,
+
+    "no-ex-assign": 2,
+
+    "no-extra-boolean-cast": 2,
+
+    "no-extra-semi": 2,
+
+    "no-func-assign": 2,
+
+    "no-inner-declarations": 2,
+
+    "no-invalid-regexp": 2,
+
+    "no-irregular-whitespace": 2,
+
+    "no-obj-calls": 2,
+
+    "no-regex-spaces": 2,
+
+    "no-sparse-arrays": 2,
+
+    "no-unexpected-multiline": 2,
+
+    "no-unreachable": 2,
+
+    "no-unsafe-finally": 2,
+
+    "no-unsafe-negation": 2,
+
+    "use-isnan": 2,
+
+    "valid-typeof": 2,
+};
+
+const bestPracticeRules = {
     "curly": 2,
 
     "guard-for-in": 2,
 
+    "no-alert": 2,
+
+    "no-bitwise": 2,
+
+    "no-case-declarations": 2,
+
+    "no-empty-pattern": 2,
+
+    "no-fallthrough": 2,
+
+    "no-multi-spaces": 2,
+
+    "no-octal": 2,
+
+    "no-redeclare": 2,
+
+    "no-self-assign": 2,
+
+    "no-unused-labels": 2,
+
     "no-void": 2,
 
     "radix": 2,
+};
 
-    "no-alert": 2,
-
-    "eol-last": 2,
-
-    "no-bitwise": 2,
+const strictModeRules = {
+    "strict": 2,
 };
 
 const variablesRules = {
+    "no-delete-var": 2,
+
+    "no-undef": 2,
+
+    "no-unused-vars": 2,
+
     "no-use-before-define": [2, "nofunc"],
 };
 
 const styleRules = {
     "brace-style": [2, "stroustrup", { allowSingleLine: true }],
 
+    "eol-last": 2,
+
     "indent": [2, 4, { SwitchCase: 1 }],
+
+    "keyword-spacing": 2,
 
     "linebreak-style": [2, "unix"],
 
-    "space-infix-ops": 2,
+    "max-len": [2, 205, 4],
+
+    "no-mixed-spaces-and-tabs": 2,
 
     "no-multiple-empty-lines": [2, { max: 1 }],
 
     "one-var": [2, never],
 
-    "no-multi-spaces": 2,
-
     "operator-linebreak": [2, "after"],
-
-    "keyword-spacing": 2,
 
     "space-before-blocks": 2,
 
@@ -46,13 +126,25 @@ const styleRules = {
 
     "spaced-comment": 2,
 
-    "max-len": [2, 205, 4],
+    "space-infix-ops": 2,
 };
 
 const es6Rules = {
     "arrow-spacing": 2,
 
+    "constructor-super": 2,
+
+    "no-class-assign": 2,
+
+    "no-const-assign": 2,
+
+    "no-dupe-class-members": 2,
+
     "no-duplicate-imports": 2,
+
+    "no-new-symbol": 2,
+
+    "no-this-before-super": 2,
 
     "no-useless-constructor": 2,
 
@@ -64,11 +156,10 @@ const es6Rules = {
 
     "prefer-spread": 2,
 
-    "arrow-parens": [2, "as-needed"],
+    "require-yield": 2,
 };
 
 const reactRules = {
-
     "no-deprecated": 2,
 
     "no-direct-mutation-state": 2,
@@ -105,7 +196,7 @@ const reactRules = {
 
     "jsx-pascal-case": 2,
 
-    "jsx-max-props-per-line": [2, { maximum: 3 }],
+    "jsx-max-props-per-line": [2, { maximum: 5 }],
 
     "jsx-no-duplicate-props": 2,
 
@@ -119,10 +210,6 @@ const reactRules = {
 };
 
 module.exports = {
-    extends: [
-        "eslint:recommended"
-    ],
-
     env: {
         browser: true,
         node: true,
@@ -139,7 +226,9 @@ module.exports = {
 
     rules: Object.assign(
         {},
-        bestPractices,
+        possibleErrorRules,
+        bestPracticeRules,
+        strictModeRules,
         variablesRules,
         styleRules,
         es6Rules,


### PR DESCRIPTION
## Major change

Biggest change with this PR is that we don't extend recommended rulesets. Me, @nene, Joachim and Andres had a bigger discussions about this in Jira and face-to-face meetings. This is our conclusion:

**Pros**
- Up to date - deprecated/removed rules are replaced with new ones
- Rules are based on JS community conventions

**Cons**
- The recommended rules can change from release to release (ESLint recommended subset can change only at major versions of ESLint)
  - When new recommended rule is added, this might unexpectedly break build when upgrading  ESLint
  - When a rule is removed then everything will lint just fine, but errors that you though a linter should catch will start to slip through
- Unwanted rules - some rules need to be disabled

**Who extend some recommended rulesets:**

* Flet https://github.com/Flet/eslint-config-semistandard

**Who do not extend any recommended rulesets:**

* airbnb https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb-base
* google https://github.com/google/eslint-config-google
* VueJS https://github.com/vuejs/eslint-config-vue
* LeanKit https://github.com/LeanKit-Labs/eslint-config-leankit
* XO https://github.com/sindresorhus/eslint-config-xo
* cleanjs https://github.com/bodil/eslint-config-cleanjs
* strongloop https://github.com/strongloop/eslint-config-strongloop
* Egg https://github.com/eggjs/eslint-config-egg


## Minor changes
I removed "arrow-parens" rules, because in XRebel we write `(a) => ...` and in XHub writes `a => ...`, so it conflicts.

I added "strict" rule, but I'm not sure if this suits with XHub code.

## Questions

There are some rules that have different cfg:
- "jsx-max-props-per-line"- XRebel has max 3, XHub max 5
- "max-len" - XRebel has 140, XHub 205.

Can XHub also use XRebel cfg or we just stay to max 5 and 205 values?
Does XHub use propTypes?