### PR TITLE
Use babel/semi

### DIFF
--- a/babel.js
+++ b/babel.js
@@ -1,0 +1,7 @@
+module.exports = {
+    plugins: ["babel"],
+
+    rules: {
+        "babel/semi": 2,
+    }
+};

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 module.exports = {
     extends: [
+        './babel.js'
         './base.js',
         './react.js'
     ]

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 module.exports = {
     extends: [
-        './babel.js'
+        './babel.js',
         './base.js',
         './react.js'
     ]

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "babel-eslint": ">=7.0.0",
     "eslint-plugin-babel": ">=4.1.1",
     "eslint-plugin-react": ">=6.4.0"
-    "eslint-plugin-react": ">=6.7.0"
   },
   "engines": {
     "node": ">= 6"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/zeroturnaround/eslint-config-zt"
   },
   "scripts": {
-      "test": "eslint -c ./index.js ."
+    "test": "eslint -c ./index.js ."
   },
   "keywords": [
     "eslint",
@@ -24,14 +24,17 @@
   },
   "homepage": "https://github.com/zeroturnaround/eslint-config-zt",
   "devDependencies": {
-    "eslint": "^3.7.1",
     "babel-eslint": "^7.0.0",
+    "eslint": "^3.7.1",
+    "eslint-plugin-babel": "^4.1.1",
     "eslint-plugin-react": "^6.4.0"
   },
   "peerDependencies": {
     "eslint": ">=3.7.1",
     "babel-eslint": ">=7.0.0",
+    "eslint-plugin-babel": ">=4.1.1",
     "eslint-plugin-react": ">=6.4.0"
+    "eslint-plugin-react": ">=6.7.0"
   },
   "engines": {
     "node": ">= 6"


### PR DESCRIPTION
Use babel/semi instead of eslint semi.

The reason is that babel/semi also supports semi-colon enforcing on class properties. Eslint semi does not support this because class properties are only at stage-2 and eslint only wants to support features which are finalised.

eslint-plugin-babel implements rules for babel-specific features that are stage0-3, though there are not many rules there: https://github.com/babel/eslint-plugin-babel

<img width="462" alt="screen shot 2017-05-30 at 22 13 34" src="https://cloud.githubusercontent.com/assets/9586897/26600577/42c9979e-4585-11e7-9774-9840bb47da5c.png">
